### PR TITLE
Set empty prefix as undefined in inputbinding

### DIFF
--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -56,7 +56,7 @@ export function assignLoadListing (input: cwltsauto.CommandInputParameter, loadL
 function createBinding (position: number, prefix: string): cwltsauto.CommandLineBinding {
     return new cwltsauto.CommandLineBinding({
             position: position,
-            prefix: prefix
+            prefix: prefix == "" ? undefined : prefix
     })
 }
 


### PR DESCRIPTION
Not specifying a prefix should result in the prefix field not being present in the generated input binding. Currently, a prefix with an empty string as value is generated. This can lead to unwanted behavior because the command constructed by CWL will take the empty prefixes into account.
See: https://github.com/nfdi4plants/CWLGenerator/issues/1#issuecomment-1196610166

This PR fixes the issue by setting the prefix to undefined when the prefix string is empty.